### PR TITLE
Scroll to top at each step

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,7 +126,7 @@ function loadPage (target: Target) {
 	};
 
 	const pre = `<!DOCTYPE html>
-	<html lang="en">
+<html lang="en">
 	<head>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -138,11 +138,26 @@ function loadPage (target: Target) {
 		<script src="https://datastax-academy.github.io/katapod-shared-assets/quiz/main.js"></script>
 	</head>
 	<body>`;
-	const post = `</body></html>`;
+	const post = `
+		<script>
+			// adapted from: https://code.visualstudio.com/api/extension-guides/webview#scripts-and-message-passing
+			window.addEventListener('message', event => {
+				const message = event.data;
+				switch(message.command){
+					case 'scroll_to_top':
+						window.scrollTo(0, 0);
+						break;
+				}
+			});
+		</script>
+	</body>
+</html>`;
 	var result = md.render((fs.readFileSync(file.fsPath, 'utf8')));
 
 	panel.webview.html = pre + result + post;
-	vscode.commands.executeCommand('notifications.clearAll');
+	vscode.commands.executeCommand('notifications.clearAll').then( () => {
+		panel.webview.postMessage({command: 'scroll_to_top'});
+	});
 }
 
 function sendText (command: any) {


### PR DESCRIPTION
For "stepX.md" files with long content it was observed that after hitting navigation buttons (Next/Prev) the webview would show the content of the newly-loaded step, but vertically scrolled to the same position as the page shown previously.
This is disconcerting to the user as they usually want to start the next step in the sequence from the beginning.
This solution, which uses messages to the webview as outlined [here](https://code.visualstudio.com/api/extension-guides/webview#scripts-and-message-passing), makes sure to always land at top of page as each step is loaded and displayed.

To test it, simply create a scenario with two consecutive steps long enough to need a scrollbar and place the navigation buttons in several points of them.