### PR TITLE
Syntax highlighting, mark-as-executed, transitional CSS, rendering refactoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "url": "https://github.com/HadesArchitect/katapod"
     },
     "description": "",
-    "version": "1.1.0-beta1",
+    "version": "1.1.0-beta2",
     "license": "Apache-2.0",
     "engines": {
         "vscode": "^1.64.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "url": "https://github.com/HadesArchitect/katapod"
     },
     "description": "",
-    "version": "1.0.0",
+    "version": "1.1.0-beta1",
     "license": "Apache-2.0",
     "engines": {
         "vscode": "^1.64.0"
@@ -18,7 +18,7 @@
         "onStartupFinished",
         "onCommand:katapod.reloadPage"
     ],
-	"main": "./out/extension.js",
+    "main": "./out/extension.js",
     "contributes": {
         "commands": [
             {
@@ -34,43 +34,44 @@
         ],
         "menus": {
             "editor/title": [
-              {
-                "when": "resourceLangId == markdown",
-                "command": "katapod.start",
-                "group": "katapod"
-              },
-              {
-                "when": "resourceLangId == markdown",
-                "command": "katapod.reloadPage",
-                "group": "katapod"
-              }
+                {
+                    "when": "resourceLangId == markdown",
+                    "command": "katapod.start",
+                    "group": "katapod"
+                },
+                {
+                    "when": "resourceLangId == markdown",
+                    "command": "katapod.reloadPage",
+                    "group": "katapod"
+                }
             ]
-          }
+        }
     },
-	"scripts": {
-		"vscode:prepublish": "yarn run compile",
-		"compile": "tsc -p ./",
-		"watch": "tsc -watch -p ./",
-		"pretest": "yarn run compile && yarn run lint",
-		"lint": "eslint src --ext ts",
-		"test": "node ./out/test/runTest.js"
-	},
+    "scripts": {
+        "vscode:prepublish": "yarn run compile",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./",
+        "pretest": "yarn run compile && yarn run lint",
+        "lint": "eslint src --ext ts",
+        "test": "node ./out/test/runTest.js"
+    },
     "dependencies": {
+        "highlight.js": "^11.7.0",
         "markdown-it": "^12.3.2",
         "markdown-it-attrs": "^4.1.3",
         "markdown-it-textual-uml": "^0.11.0"
     },
     "devDependencies": {
-		"@types/vscode": "^1.64.0",
-		"@types/glob": "^7.2.0",
-		"@types/mocha": "^9.1.1",
-		"@types/node": "14.x",
-		"@typescript-eslint/eslint-plugin": "^5.21.0",
-		"@typescript-eslint/parser": "^5.21.0",
-		"eslint": "^8.14.0",
-		"glob": "^8.0.1",
-		"mocha": "^9.2.2",
-		"typescript": "^4.6.4",
-		"@vscode/test-electron": "^2.1.3"
+        "@types/glob": "^7.2.0",
+        "@types/mocha": "^9.1.1",
+        "@types/node": "14.x",
+        "@types/vscode": "^1.64.0",
+        "@typescript-eslint/eslint-plugin": "^5.21.0",
+        "@typescript-eslint/parser": "^5.21.0",
+        "@vscode/test-electron": "^2.1.3",
+        "eslint": "^8.14.0",
+        "glob": "^8.0.1",
+        "mocha": "^9.2.2",
+        "typescript": "^4.6.4"
     }
 }

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -25,37 +25,7 @@ const stepPageHtmlPrefix = `
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.7.0/build/styles/default.min.css">
-		<link rel="stylesheet" type="text/css" href="https://datastax-academy.github.io/katapod-shared-assets/css/katapod.css" />
-		<style>
-			pre code.executable {
-				cursor: pointer;
-				background-color: lightgray;
-			}
-			pre code.nonexecutable {
-				cursor: default;
-				background-color: #B0CFFF;
-			}
-			a.codeblock {
-				text-decoration: none;
-			}
-			pre code.codeblock {
-				text-decoration: none;
-				color: black;
-				padding: 10px 10px;
-				margin-left: 10px;
-				width: 98%;
-				display: block;
-			}
-			pre code.executed {
-				box-shadow: -8px 0px 0px 0px rgba(0, 0, 0, 1.0);
-			}
-			pre code.codeblock:focus {
-				outline: none !important;
-			}
-			code.inline_code {
-				color: #7F1FAA;
-			}
-		</style>
+		<link rel="stylesheet" type="text/css" href="https://datastax-academy.github.io/katapod-shared-assets/css/katapodv2.css" />
 		<script src="https://datastax-academy.github.io/katapod-shared-assets/js/katapod.js"></script>
 		<link rel="stylesheet" type="text/css" href="https://datastax-academy.github.io/katapod-shared-assets/quiz/quiz.css" />
 		<link rel="stylesheet" type="text/css" href="https://datastax-academy.github.io/katapod-shared-assets/quiz/page.css" />

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -7,6 +7,7 @@ import * as path from "path";
 const fs = require("fs");
 const markdownIt = require("markdown-it");
 const markdownItAttrs = require("markdown-it-attrs");
+const highlightjs = require('highlight.js'); // https://highlightjs.org
 
 import {runCommandsPerTerminal, ConfigCommand, FullCommand, cbIdSeparator} from "./runCommands";
 import {buildFullFileUri} from "./filesystem";
@@ -16,13 +17,45 @@ import {log} from "./logging";
 
 const executionInfoPrefix = "### ";
 const defaultCodeBlockMaxInvocations = "unlimited";
+
 const stepPageHtmlPrefix = `
 <!DOCTYPE html>
 <html lang="en">
 	<head>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.7.0/build/styles/default.min.css">
 		<link rel="stylesheet" type="text/css" href="https://datastax-academy.github.io/katapod-shared-assets/css/katapod.css" />
+		<style>
+			pre code.executable {
+				cursor: pointer;
+				background-color: lightgray;
+			}
+			pre code.nonexecutable {
+				cursor: default;
+				background-color: #B0CFFF;
+			}
+			a.codeblock {
+				text-decoration: none;
+			}
+			pre code.codeblock {
+				text-decoration: none;
+				color: black;
+				padding: 10px 10px;
+				margin-left: 10px;
+				width: 98%;
+				display: block;
+			}
+			pre code.executed {
+				box-shadow: -8px 0px 0px 0px rgba(0, 0, 0, 1.0);
+			}
+			pre code.codeblock:focus {
+				outline: none !important;
+			}
+			code.inline_code {
+				color: #7F1FAA;
+			}
+		</style>
 		<script src="https://datastax-academy.github.io/katapod-shared-assets/js/katapod.js"></script>
 		<link rel="stylesheet" type="text/css" href="https://datastax-academy.github.io/katapod-shared-assets/quiz/quiz.css" />
 		<link rel="stylesheet" type="text/css" href="https://datastax-academy.github.io/katapod-shared-assets/quiz/page.css" />
@@ -40,6 +73,12 @@ const stepPageHtmlPostfix = `
 					case "scroll_to_top":
 						window.scrollTo(0, 0);
 						break;
+					case "mark_executed_block":
+						const codeBlock = document.getElementById(message.blockId);
+						if (codeBlock) {
+							codeBlock.classList.add("executed");
+							break;
+						}
 				}
 			});
 		</script>
@@ -148,6 +187,26 @@ export function isLocalImageSrc(imgSrc: string): boolean {
 	return imgSrc.indexOf(fullRemoteUriSnippet) < 0;
 }
 
+function normalizeSyntaxLanguage(lang0: string): string {
+	if (lang0.toLowerCase() === 'cql') {
+		// Note: maybe one day we will add CQL syntax to hightlight.js ...
+		return 'sql';
+	} else {
+		return lang0.toLowerCase();
+	}
+}
+
+function renderHighlightedCode(codeStr: string, lang: string, markdownIt: any): string {
+	// adapted from: https://github.com/markdown-it/markdown-it#syntax-highlighting
+	const langNorm = normalizeSyntaxLanguage(lang);
+	if (langNorm && highlightjs.getLanguage(langNorm)) {
+		try {
+			return highlightjs.highlight(codeStr, { language: langNorm }).value;
+		} catch (__) {}
+	}	
+	return markdownIt.utils.escapeHtml(codeStr); // use external default escaping
+};
+
 export function loadPage(target: TargetStep, env: KatapodEnvironment) {
 	env.state.stepHistory.push(target.step);
 	log("debug", `[loadPage] Step history: ${env.state.stepHistory.map(s => s.toString()).join(" => ")}`);
@@ -160,29 +219,41 @@ export function loadPage(target: TargetStep, env: KatapodEnvironment) {
 
 	let blockIndex = 0;
 
+	// process inline code
+	md.renderer.rules.code_inline = function (tokens: any, idx: any, options: any, env: any, slf: any) {
+		// modified from: https://github.com/markdown-it/markdown-it/blob/master/lib/renderer.js#L21-L27
+		var token = tokens[idx];
+		return  '<code class="inline_code"' + slf.renderAttrs(token) + '>' +
+				md.utils.escapeHtml(token.content) +
+				'</code>';
+	};
+	
 	// process codeblocks
 	md.renderer.rules.fence_default = md.renderer.rules.fence;
 	md.renderer.rules.fence = function (tokens: any, idx: any, options: any, env: any, slf: any) {
-		var token = tokens[idx],
-			info = token.info ? md.utils.unescapeAll(token.info).trim() : "";
-
-		if (info) { // Fallback to the default processor
-			return md.renderer.rules.fence_default(tokens, idx, options, env, slf);
-		}
+		var token = tokens[idx];
+		// 'info' is assumed to be a single word = a syntax specifier, or ''.
+		var info = token.info ? md.utils.unescapeAll(token.info).trim() : "";
 
 		const parsedCommand: FullCommand = parseCodeBlockContent(target.step, blockIndex, tokens[idx].content);
+		var renderedCode: string = renderHighlightedCode(parsedCommand.command, info, md);
+
 		blockIndex++;
 
-		if(parsedCommand.execute !== false) {
-			return  `<pre` + slf.renderAttrs(token) + ` title="Click <play button> to execute!"><code>` + `<a class="command_link" title="Click to execute!" class="button1" href="command:katapod.sendText?` + 
-				renderCommandUri(parsedCommand) + `">▶</a>` + 
-				md.utils.escapeHtml(parsedCommand.command) +
-			"</code></pre>\n";
-		}else{
-			return  "<pre><code>" + 
-				md.utils.escapeHtml(parsedCommand.command) +
-				"</code></pre>\n";
-		}
+		const suppressExecution = parsedCommand.execute === false;
+
+		const executionHref = `command:katapod.sendText?${renderCommandUri(parsedCommand)}`;
+		const aSpanEle = suppressExecution ? '<span>': `<a class="codeblock" title="Click to execute" href="${executionHref}">`;
+		const aSpanEleCloser = suppressExecution ? '</span>': '</a>';
+		const preEle = `<pre` + slf.renderAttrs(token) + `>`;
+		const codeEleClasses = suppressExecution ? "codeblock nonexecutable" : "codeblock executable";
+		const codeEle = `<code id="${parsedCommand.codeBlockId}" class="${codeEleClasses}">`;
+
+		return `${aSpanEle}
+		${preEle}
+		${codeEle}${renderedCode}</code>
+		</pre>
+		${aSpanEleCloser}`;
 
 	};
 
@@ -213,7 +284,7 @@ export function loadPage(target: TargetStep, env: KatapodEnvironment) {
 			tokens[idx].attrs[srcIndex][1] = imgPanelUri;
 		}
 		return imageDefault(tokens, idx, options, env, self);
-	}
+	};
 
 	var result = md.render((fs.readFileSync(file.fsPath, "utf8")));
 

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -249,11 +249,7 @@ export function loadPage(target: TargetStep, env: KatapodEnvironment) {
 		const codeEleClasses = suppressExecution ? "codeblock nonexecutable" : "codeblock executable";
 		const codeEle = `<code id="${parsedCommand.codeBlockId}" class="${codeEleClasses}">`;
 
-		return `${aSpanEle}
-		${preEle}
-		${codeEle}${renderedCode}</code>
-		</pre>
-		${aSpanEleCloser}`;
+		return `${aSpanEle}${preEle}${codeEle}${renderedCode}</code></pre>${aSpanEleCloser}`;
 
 	};
 

--- a/src/runCommands.ts
+++ b/src/runCommands.ts
@@ -62,7 +62,9 @@ export function runCommand(fullCommand: FullCommand, env: KatapodEnvironment) {
 			env.state.codeInvocationCount[fullCommand.codeBlockId] = (env.state.codeInvocationCount[fullCommand.codeBlockId] || 0) +1;
 			// actually launch the command:
 			targetTerminal.sendText(fullCommand.command);
-			vscode.commands.executeCommand("notifications.clearAll");
+			vscode.commands.executeCommand("notifications.clearAll").then( () => {
+				env.components.panel.webview.postMessage({command: "mark_executed_block", "blockId": fullCommand.codeBlockId});
+			});
 		} else {
 			log("debug", `[runCommand]: Refusing to execute ${JSON.stringify(fullCommand)} (invocations detected: ${invocationCountSoFar})`);
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,6 +772,11 @@
   "resolved" "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   "version" "1.2.0"
 
+"highlight.js@^11.7.0":
+  "integrity" "sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ=="
+  "resolved" "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz"
+  "version" "11.7.0"
+
 "http-proxy-agent@^4.0.1":
   "integrity" "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg=="
   "resolved" "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz"


### PR DESCRIPTION
Four independent improvements put together:

* modified to rely on the transitional "katapodv2.css" to better iterate without damaging previous version
* syntax highlighting implemented through `highlight.js` (ordinary marker at the three-backtick symbol, accepts "cql")
* rendering code, refactored for better modularity
* mark-as-executed for code blocks (uses messaging between extension and rendered page)